### PR TITLE
[#1][cc] Add "none" congestion control algorithm

### DIFF
--- a/quiche/include/quiche.h
+++ b/quiche/include/quiche.h
@@ -234,6 +234,7 @@ void quiche_config_set_initial_congestion_window_packets(quiche_config *config, 
 enum quiche_cc_algorithm {
     QUICHE_CC_RENO = 0,
     QUICHE_CC_CUBIC = 1,
+    QUICHE_CC_NONE = 2,
     QUICHE_CC_BBR2_GCONGESTION = 4,
 };
 

--- a/quiche/src/recovery/congestion/mod.rs
+++ b/quiche/src/recovery/congestion/mod.rs
@@ -283,6 +283,7 @@ impl From<CongestionControlAlgorithm> for &'static CongestionControlOps {
         match algo {
             CongestionControlAlgorithm::Reno => &reno::RENO,
             CongestionControlAlgorithm::CUBIC => &cubic::CUBIC,
+            CongestionControlAlgorithm::None => &none::NONE,
             // Bbr2Gcongestion is routed to the congestion implementation in
             // the gcongestion directory by Recovery::new_with_config;
             // LegacyRecovery never gets a RecoveryConfig with the
@@ -348,6 +349,7 @@ mod tests {
 mod cubic;
 mod delivery_rate;
 mod hystart;
+mod none;
 mod prr;
 pub(crate) mod recovery;
 mod reno;

--- a/quiche/src/recovery/congestion/none.rs
+++ b/quiche/src/recovery/congestion/none.rs
@@ -1,0 +1,147 @@
+// Copyright (C) 2026, Cloudflare, Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+// IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+//! No Congestion Control
+//!
+//! This module implements a no-op congestion control algorithm that sets the
+//! congestion window to its maximum value and never reduces it. Useful for
+//! testing and controlled network environments.
+
+use std::time::Instant;
+
+use super::rtt::RttStats;
+use super::Acked;
+use super::Congestion;
+use super::CongestionControlOps;
+use super::Sent;
+
+pub(crate) static NONE: CongestionControlOps = CongestionControlOps {
+    on_init,
+    on_packet_sent,
+    on_packets_acked,
+    congestion_event,
+    checkpoint,
+    rollback,
+    #[cfg(feature = "qlog")]
+    state_str,
+    debug_fmt,
+};
+
+fn on_init(r: &mut Congestion) {
+    r.congestion_window = usize::MAX;
+}
+
+fn on_packet_sent(
+    _r: &mut Congestion, _sent_bytes: usize, _bytes_in_flight: usize,
+    _now: Instant,
+) {
+}
+
+fn on_packets_acked(
+    _r: &mut Congestion, _bytes_in_flight: usize, packets: &mut Vec<Acked>,
+    _now: Instant, _rtt_stats: &RttStats,
+) {
+    packets.clear();
+}
+
+fn congestion_event(
+    _r: &mut Congestion, _bytes_in_flight: usize, _lost_bytes: usize,
+    _largest_lost_pkt: &Sent, _now: Instant,
+) {
+}
+
+fn checkpoint(_r: &mut Congestion) {}
+
+fn rollback(_r: &mut Congestion) -> bool {
+    true
+}
+
+#[cfg(feature = "qlog")]
+fn state_str(_r: &Congestion, _now: Instant) -> &'static str {
+    "none"
+}
+
+fn debug_fmt(
+    _r: &Congestion, f: &mut std::fmt::Formatter,
+) -> std::fmt::Result {
+    write!(f, "none")
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::CongestionControlAlgorithm;
+
+    use crate::recovery::congestion::recovery::LegacyRecovery;
+    use crate::recovery::congestion::test_sender::TestSender;
+    use crate::recovery::RecoveryOps;
+
+    fn test_sender() -> TestSender {
+        TestSender::new(CongestionControlAlgorithm::None, false)
+    }
+
+    #[test]
+    fn none_init() {
+        let mut cfg = crate::Config::new(crate::PROTOCOL_VERSION).unwrap();
+        cfg.set_cc_algorithm(CongestionControlAlgorithm::None);
+
+        let r = LegacyRecovery::new(&cfg);
+
+        assert_eq!(r.cwnd(), usize::MAX);
+        assert_eq!(r.bytes_in_flight(), 0);
+    }
+
+    #[test]
+    fn none_no_window_reduction_on_loss() {
+        let mut sender = test_sender();
+        let size = sender.max_datagram_size;
+
+        sender.send_packet(size);
+        sender.lose_n_packets(1, size, None);
+
+        assert_eq!(sender.congestion_window, usize::MAX);
+    }
+
+    #[test]
+    fn none_window_unchanged_after_ack() {
+        let mut sender = test_sender();
+        let size = sender.max_datagram_size;
+
+        for _ in 0..5 {
+            sender.send_packet(size);
+        }
+
+        let cwnd_before = sender.congestion_window;
+        sender.ack_n_packets(3, size);
+
+        assert_eq!(sender.congestion_window, cwnd_before);
+    }
+
+    #[test]
+    fn none_from_string() {
+        let algo: CongestionControlAlgorithm = "none".parse().unwrap();
+        assert_eq!(algo, CongestionControlAlgorithm::None);
+    }
+}

--- a/quiche/src/recovery/mod.rs
+++ b/quiche/src/recovery/mod.rs
@@ -365,6 +365,8 @@ pub enum CongestionControlAlgorithm {
     Reno            = 0,
     /// CUBIC congestion control algorithm (default). `cubic` in a string form.
     CUBIC           = 1,
+    /// No congestion control. `none` in a string form.
+    None            = 2,
     /// BBRv2 congestion control algorithm implementation from gcongestion
     /// branch. `bbr2_gcongestion` in a string form.
     Bbr2Gcongestion = 4,
@@ -380,6 +382,7 @@ impl FromStr for CongestionControlAlgorithm {
         match name {
             "reno" => Ok(CongestionControlAlgorithm::Reno),
             "cubic" => Ok(CongestionControlAlgorithm::CUBIC),
+            "none" => Ok(CongestionControlAlgorithm::None),
             "bbr" => Ok(CongestionControlAlgorithm::Bbr2Gcongestion),
             "bbr2" => Ok(CongestionControlAlgorithm::Bbr2Gcongestion),
             "bbr2_gcongestion" => Ok(CongestionControlAlgorithm::Bbr2Gcongestion),
@@ -757,6 +760,10 @@ mod tests {
         assert_eq!(algo, CongestionControlAlgorithm::CUBIC);
         assert!(!recovery_for_alg(algo).gcongestion_enabled());
 
+        let algo = CongestionControlAlgorithm::from_str("none").unwrap();
+        assert_eq!(algo, CongestionControlAlgorithm::None);
+        assert!(!recovery_for_alg(algo).gcongestion_enabled());
+
         let algo = CongestionControlAlgorithm::from_str("bbr").unwrap();
         assert_eq!(algo, CongestionControlAlgorithm::Bbr2Gcongestion);
         assert!(recovery_for_alg(algo).gcongestion_enabled());
@@ -781,7 +788,7 @@ mod tests {
 
     #[rstest]
     fn loss_on_pto(
-        #[values("reno", "cubic", "bbr2_gcongestion")] cc_algorithm_name: &str,
+        #[values("reno", "cubic", "none", "bbr2_gcongestion")] cc_algorithm_name: &str,
     ) {
         let mut cfg = Config::new(crate::PROTOCOL_VERSION).unwrap();
         assert_eq!(cfg.set_cc_algorithm_name(cc_algorithm_name), Ok(()));
@@ -1067,7 +1074,7 @@ mod tests {
 
     #[rstest]
     fn loss_on_timer(
-        #[values("reno", "cubic", "bbr2_gcongestion")] cc_algorithm_name: &str,
+        #[values("reno", "cubic", "none", "bbr2_gcongestion")] cc_algorithm_name: &str,
     ) {
         let mut cfg = Config::new(crate::PROTOCOL_VERSION).unwrap();
         assert_eq!(cfg.set_cc_algorithm_name(cc_algorithm_name), Ok(()));
@@ -1263,7 +1270,7 @@ mod tests {
 
     #[rstest]
     fn loss_on_reordering(
-        #[values("reno", "cubic", "bbr2_gcongestion")] cc_algorithm_name: &str,
+        #[values("reno", "cubic", "none", "bbr2_gcongestion")] cc_algorithm_name: &str,
     ) {
         let mut cfg = Config::new(crate::PROTOCOL_VERSION).unwrap();
         assert_eq!(cfg.set_cc_algorithm_name(cc_algorithm_name), Ok(()));


### PR DESCRIPTION
## Summary
- Add a no-op `"none"` congestion control algorithm (`CongestionControlAlgorithm::None = 2`) that sets `cwnd = usize::MAX` and never reduces it
- Wire through enum, `FromStr`, `CongestionControlOps` dispatch, and C header (`QUICHE_CC_NONE = 2`)
- Add 4 unit tests for init, loss, ack, and string parsing in `none.rs`, plus update `loss_on_pto`, `loss_on_timer`, `loss_on_reordering`, and `lookup_cc_algo_ok` tests

## Test plan
- [x] `cargo build -p quiche` compiles successfully
- [x] `cargo test -p quiche` — all 929 existing tests pass
- [x] `cargo test -p quiche -- none` — all 7 none-related tests pass
- [x] `cargo build -p quiche --features ffi` — FFI builds with new `QUICHE_CC_NONE` enum value

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)