### PR TITLE
Reduce generic buffer pool size to 64 entries

### DIFF
--- a/tokio-quiche/src/buf_factory.rs
+++ b/tokio-quiche/src/buf_factory.rs
@@ -45,7 +45,7 @@ use buffer_pool::Pooled;
 use datagram_socket::MAX_DATAGRAM_SIZE;
 
 const POOL_SHARDS: usize = 8;
-const POOL_SIZE: usize = 128;
+const POOL_SIZE: usize = 64;
 const DATAGRAM_POOL_SIZE: usize = 64 * 1024;
 
 const TINY_BUF_SIZE: usize = 64;


### PR DESCRIPTION
## Summary
- Further reduce `POOL_SIZE` from 128 to 64 entries in `tokio-quiche/src/buf_factory.rs` to lower idle memory usage.
- Follows up on 6ef79814 which reduced from 16k to 128.

## Test plan
- [ ] Verify compilation passes
- [ ] Run existing tests to ensure no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)